### PR TITLE
feat: swagger implementations

### DIFF
--- a/apps/backend-js/.gitignore
+++ b/apps/backend-js/.gitignore
@@ -1,0 +1,37 @@
+
+# Dependencies
+node_modules
+.pnp
+.pnp.js
+
+# Local env files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Testing
+coverage
+
+# Turbo
+.turbo
+
+# Vercel
+.vercel
+
+# Build Outputs
+.next/
+out/
+build
+dist
+
+
+# Debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Misc
+.DS_Store
+*.pem

--- a/apps/backend-js/README.md
+++ b/apps/backend-js/README.md
@@ -12,7 +12,7 @@ This implementation provides:
 - **Capability Registry** - Map endpoints to required UCAN capabilities
 - **UCAN Validator Middleware** - Validate Bearer tokens with capability checking
 - **Example Token Generator** - Auto-generate valid UCANs for testing
-- **Interactive Swagger UI** - Try endpoints with real UCAN tokens
+- **Interactive Swagger UI** - Try endpoints with UCAN tokens
 
 ---
 
@@ -25,7 +25,7 @@ yarn >= 1.22.0
 ### Installation
 ```bash
 # Clone the repository
-git clone https://github.com/your-org/ucan-visualization-app
+git clone https://github.com/Goddhi/UCAN-visualization-app
 cd ucan-visualization-app/apps/backend-js
 
 # Install dependencies

--- a/apps/backend-js/README.md
+++ b/apps/backend-js/README.md
@@ -1,0 +1,205 @@
+# UCAN Swagger Documentation Pattern
+
+> **A reusable pattern for documenting UCAN-based APIs with OpenAPI/Swagger**
+
+Add interactive API documentation to any UCAN-secured service with capability-based authorization, example token generation, and automatic validation.
+
+---
+
+A **complete reference implementation** showing how to integrate UCAN (User Controlled Authorization Networks) with OpenAPI/Swagger documentation.
+
+This implementation provides:
+- **Capability Registry** - Map endpoints to required UCAN capabilities
+- **UCAN Validator Middleware** - Validate Bearer tokens with capability checking
+- **Example Token Generator** - Auto-generate valid UCANs for testing
+- **Interactive Swagger UI** - Try endpoints with real UCAN tokens
+
+---
+
+### Prerequisites
+```bash
+node >= 18.0.0
+yarn >= 1.22.0
+```
+
+### Installation
+```bash
+# Clone the repository
+git clone https://github.com/your-org/ucan-visualization-app
+cd ucan-visualization-app/apps/backend-js
+
+# Install dependencies
+yarn install
+
+# Start the server
+yarn dev
+```
+
+### Visit the Documentation
+```
+http://localhost:8081/swagger
+```
+
+## How to Use This Pattern
+
+### Step 1: Copy the Core Files
+
+Copy these files to your project:
+```bash
+# Required files
+src/middleware/ucanValidator.js
+src/swagger/capabilities.js
+src/swagger/config.js
+src/swagger/examples.js
+```
+
+### Step 2: Define Your Service's Capabilities
+
+**File:** `src/swagger/capabilities.js`
+```javascript
+export const capabilityRegistry = {
+  'POST /your-endpoint': {
+    capabilities: [{ can: 'your/action', with: 'your:resource' }],
+    description: 'Your endpoint description'
+  }
+};
+```
+
+**Example for a file storage API:**
+```javascript
+export const capabilityRegistry = {
+  'POST /files/upload': {
+    capabilities: [{ can: 'store/add', with: 'storage:*' }],
+    description: 'Upload files to storage'
+  },
+  'GET /files/:cid': {
+    capabilities: [{ can: 'store/get', with: 'storage:*' }],
+    description: 'Download files from storage'
+  },
+  'DELETE /files/:cid': {
+    capabilities: [{ can: 'store/remove', with: 'storage:*' }],
+    description: 'Delete files from storage'
+  }
+};
+```
+
+### Step 3: Generate Example Tokens
+
+**File:** `src/swagger/examples.js`
+```javascript
+import * as ed25519 from '@ucanto/principal/ed25519';
+import * as Client from '@ucanto/client';
+
+export async function generateExampleTokens() {
+  const issuer = await ed25519.generate();
+  const audience = await ed25519.generate();
+
+  // Generate tokens for YOUR capabilities
+  const uploadToken = await Client.delegate({
+    issuer,
+    audience,
+    capabilities: [{ can: 'store/add', with: 'storage:*' }],
+    expiration: Math.floor(Date.now() / 1000) + 86400
+  });
+  
+  const archive = await uploadToken.archive();
+  return {
+    upload: Buffer.from(archive.ok).toString('base64')
+  };
+}
+```
+
+### Step 4: Configure Swagger
+
+**File:** `src/swagger/config.js`
+```javascript
+export const swaggerSpec = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Your API Name',
+    version: '1.0.0',
+    description: 'Your API description with UCAN info'
+  },
+  paths: {
+    '/your-endpoint': {
+      post: {
+        summary: 'Your endpoint',
+        description: '**Required capability:** `your/action` on `your:resource`',
+        security: [{ UCANBearer: [] }],
+        // ... rest of spec
+      }
+    }
+  }
+};
+```
+
+### Step 5: Add UCAN Validation to Your Server
+
+**File:** `src/server.js`
+```javascript
+import express from 'express';
+import swaggerUi from 'swagger-ui-express';
+import { createUcanValidator } from './middleware/ucanValidator.js';
+import { swaggerSpec } from './swagger/config.js';
+import { generateExampleTokens } from './swagger/examples.js';
+
+const app = express();
+
+// Generate example tokens on startup
+let exampleTokens = {};
+generateExampleTokens().then(tokens => {
+  exampleTokens = tokens;
+});
+
+// Enable UCAN validation
+app.use(createUcanValidator());
+
+// Swagger UI
+app.use('/swagger', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+// Example tokens endpoint
+app.get('/api/examples/tokens', (req, res) => {
+  res.json({ tokens: exampleTokens });
+});
+
+// Your routes here
+app.use('/your-routes', yourRouter);
+
+app.listen(3000);
+```
+
+---
+
+## UCAN Validation Flow
+
+### How It Works
+```
+1. Request arrives
+   ↓
+2. UCAN Validator Middleware extracts Bearer token
+   ↓
+3. Decodes UCAN using @ucanto/core/delegation
+   ↓
+4. Looks up required capabilities from registry
+   ↓
+5. Validates token has required capabilities
+   ↓
+6. Attaches delegation to req.ucan
+   ↓
+7. Proceeds to route handler OR returns 403
+```
+
+##  Testing
+
+### Generate Test Tokens
+```bash
+# Start the server
+yarn dev
+
+### Test in Swagger UI
+
+1. Visit `http://localhost:8081/swagger`
+2. Click **"Authorize"** button
+3. Enter: `Bearer <token-from-examples-endpoint>`
+4. Click **"Authorize"** then **"Close"**
+5. Try any endpoint with **"Try it out"**

--- a/apps/backend-js/package.json
+++ b/apps/backend-js/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@ucan/backend-js",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "nodemon src/server.js",
+    "start": "node src/server.js",
+    "build": "echo 'Build complete'",
+    "lint": "echo 'Lint complete'",
+    "check-types": "echo 'Type check complete'"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "multer": "^1.4.5-lts.1",
+    "@ucanto/core": "^10.0.1",
+    "@ucanto/principal": "^9.0.1",
+    "@ucanto/transport": "^9.1.1",
+    "@ucanto/server": "^10.0.0",
+    "@ucanto/client": "^9.0.1",
+    "@ipld/car": "^5.2.4",
+    "@ipld/dag-cbor": "^9.0.6",
+    "multiformats": "^12.1.3",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
+  }
+}

--- a/apps/backend-js/scripts/generate-token.mjs
+++ b/apps/backend-js/scripts/generate-token.mjs
@@ -1,0 +1,23 @@
+import * as ed25519 from '@ucanto/principal/ed25519';
+import * as Client from '@ucanto/client';
+
+async function generateTestToken() {
+  const alice = await ed25519.generate();
+  const bob = await ed25519.generate();
+
+  const delegation = await Client.delegate({
+    issuer: alice,
+    audience: bob,
+    capabilities: [{
+      can: 'store/add',
+      with: 'storage:*',
+    }],
+    expiration: Math.floor(Date.now() / 1000) + 86400,
+  });
+
+  // Use archive() method which returns the CAR bytes
+  const carBytes = await delegation.archive();
+  console.log(Buffer.from(carBytes.ok).toString('base64'));
+}
+
+generateTestToken().catch(console.error);

--- a/apps/backend-js/src/middleware/examples.js
+++ b/apps/backend-js/src/middleware/examples.js
@@ -1,0 +1,58 @@
+import * as ed25519 from '@ucanto/principal/ed25519';
+import * as Client from '@ucanto/client';
+
+/**
+ * Generate example UCAN tokens for documentation
+ */
+export async function generateExampleTokens() {
+  const issuer = await ed25519.generate();
+  const audience = await ed25519.generate();
+
+  const tokens = {};
+
+  // Parse token
+  const parseDelegation = await Client.delegate({
+    issuer,
+    audience,
+    capabilities: [{ can: 'ucan/parse', with: 'api:*' }],
+    expiration: Math.floor(Date.now() / 1000) + 86400
+  });
+  const parseArchive = await parseDelegation.archive();
+  tokens.parse = Buffer.from(parseArchive.ok).toString('base64');
+
+  // Validate token
+  const validateDelegation = await Client.delegate({
+    issuer,
+    audience,
+    capabilities: [{ can: 'ucan/validate', with: 'api:*' }],
+    expiration: Math.floor(Date.now() / 1000) + 86400
+  });
+  const validateArchive = await validateDelegation.archive();
+  tokens.validate = Buffer.from(validateArchive.ok).toString('base64');
+
+  // Graph token
+  const graphDelegation = await Client.delegate({
+    issuer,
+    audience,
+    capabilities: [{ can: 'ucan/graph', with: 'api:*' }],
+    expiration: Math.floor(Date.now() / 1000) + 86400
+  });
+  const graphArchive = await graphDelegation.archive();
+  tokens.graph = Buffer.from(graphArchive.ok).toString('base64');
+
+  // Admin token (all capabilities)
+  const adminDelegation = await Client.delegate({
+    issuer,
+    audience,
+    capabilities: [
+      { can: 'ucan/parse', with: 'api:*' },
+      { can: 'ucan/validate', with: 'api:*' },
+      { can: 'ucan/graph', with: 'api:*' }
+    ],
+    expiration: Math.floor(Date.now() / 1000) + 86400
+  });
+  const adminArchive = await adminDelegation.archive();
+  tokens.admin = Buffer.from(adminArchive.ok).toString('base64');
+
+  return tokens;
+}

--- a/apps/backend-js/src/middleware/ucanvalidator.js
+++ b/apps/backend-js/src/middleware/ucanvalidator.js
@@ -1,0 +1,75 @@
+import * as Delegation from '@ucanto/core/delegation';
+import { capabilityRegistry, hasRequiredCapability } from '../swagger/capabilities.js';
+
+/**
+ * UCAN Validator Middleware
+ * Validates Bearer tokens against required capabilities
+ */
+export function createUcanValidator() {
+  return async (req, res, next) => {
+    // Skip validation for health check and swagger
+    const publicPaths = ['/health', '/swagger', '/swagger.json', '/api/examples/tokens'];
+    if (publicPaths.some(path => req.path === path || req.path.startsWith(path))) {
+      return next();
+    }
+
+    // Get Authorization header
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({
+        error: 'Missing Authorization header',
+        message: 'Please provide a UCAN token in Authorization: Bearer <token> header'
+      });
+    }
+
+    // Extract Bearer token
+    const match = authHeader.match(/^Bearer (.+)$/);
+    if (!match) {
+      return res.status(401).json({
+        error: 'Invalid Authorization format',
+        message: 'Use format: Authorization: Bearer <base64-token>'
+      });
+    }
+
+    const tokenBase64 = match[1];
+
+    try {
+      // Decode UCAN token
+      const tokenBytes = Buffer.from(tokenBase64, 'base64');
+      const result = await Delegation.extract(tokenBytes);
+      const delegation = result.ok || result;
+
+      // Get required capabilities for this endpoint
+      const endpoint = `${req.method} ${req.path}`;
+      const requirements = capabilityRegistry[endpoint];
+
+      if (!requirements) {
+        // No specific requirements, allow
+        req.ucan = delegation;
+        return next();
+      }
+
+      // Check if delegation has required capabilities
+      const hasAllCapabilities = requirements.capabilities.every(reqCap =>
+        hasRequiredCapability(delegation, reqCap)
+      );
+
+      if (!hasAllCapabilities) {
+        return res.status(403).json({
+          error: 'Insufficient capabilities',
+          message: `Required: ${JSON.stringify(requirements.capabilities)}`,
+          provided: delegation.capabilities
+        });
+      }
+
+      // Attach delegation to request
+      req.ucan = delegation;
+      next();
+    } catch (error) {
+      return res.status(400).json({
+        error: 'Invalid UCAN token',
+        message: error.message
+      });
+    }
+  };
+}

--- a/apps/backend-js/src/routes/graph.js
+++ b/apps/backend-js/src/routes/graph.js
@@ -1,0 +1,45 @@
+import express from 'express';
+import multer from 'multer';
+
+const router = express.Router();
+const upload = multer({ limits: { fileSize: 10 * 1024 * 1024 } });
+
+export function createGraphRouter(graphService) {
+  router.post('/delegation', async (req, res) => {
+    try {
+      const { token } = req.body;
+      if (!token) {
+        return res.status(400).json({ error: 'Token is required' });
+      }
+
+      const tokenBytes = Buffer.from(token, 'base64');
+      const result = await graphService.generateDelegationGraph(tokenBytes);
+      res.json(result);
+    } catch (error) {
+      res.status(422).json({ 
+        error: 'Failed to generate graph',
+        message: error.message 
+      });
+    }
+  });
+
+  router.post('/invocation', async (req, res) => {
+    try {
+      const { token } = req.body;
+      if (!token) {
+        return res.status(400).json({ error: 'Token is required' });
+      }
+
+      const tokenBytes = Buffer.from(token, 'base64');
+      const result = await graphService.generateInvocationGraph(tokenBytes);
+      res.json(result);
+    } catch (error) {
+      res.status(422).json({ 
+        error: 'Failed to generate invocation graph',
+        message: error.message 
+      });
+    }
+  });
+
+  return router;
+}

--- a/apps/backend-js/src/routes/parse.js
+++ b/apps/backend-js/src/routes/parse.js
@@ -1,0 +1,79 @@
+import express from 'express';
+import multer from 'multer';
+
+const router = express.Router();
+const upload = multer({ limits: { fileSize: 10 * 1024 * 1024 } });
+
+export function createParseRouter(parserService) {
+  router.post('/delegation', async (req, res) => {
+    try {
+      const { token } = req.body;
+      if (!token) {
+        return res.status(400).json({ error: 'Token is required' });
+      }
+
+      const tokenBytes = Buffer.from(token, 'base64');
+      const result = await parserService.parseDelegation(tokenBytes);
+      res.json(result);
+    } catch (error) {
+      res.status(422).json({ 
+        error: 'Failed to parse delegation',
+        message: error.message 
+      });
+    }
+  });
+
+  router.post('/chain', async (req, res) => {
+    try {
+      const { token } = req.body;
+      if (!token) {
+        return res.status(400).json({ error: 'Token is required' });
+      }
+
+      const tokenBytes = Buffer.from(token, 'base64');
+      const result = await parserService.parseDelegationChain(tokenBytes);
+      res.json(result);
+    } catch (error) {
+      res.status(422).json({ 
+        error: 'Failed to parse chain',
+        message: error.message 
+      });
+    }
+  });
+
+  router.post('/invocation', async (req, res) => {
+    try {
+      const { token } = req.body;
+      if (!token) {
+        return res.status(400).json({ error: 'Token is required' });
+      }
+
+      const tokenBytes = Buffer.from(token, 'base64');
+      const result = await parserService.parseInvocation(tokenBytes);
+      res.json(result);
+    } catch (error) {
+      res.status(422).json({ 
+        error: 'Failed to parse invocation',
+        message: error.message 
+      });
+    }
+  });
+
+  router.post('/delegation/file', upload.single('file'), async (req, res) => {
+    try {
+      if (!req.file) {
+        return res.status(400).json({ error: 'File is required' });
+      }
+
+      const result = await parserService.parseDelegation(req.file.buffer);
+      res.json(result);
+    } catch (error) {
+      res.status(422).json({ 
+        error: 'Failed to parse file',
+        message: error.message 
+      });
+    }
+  });
+
+  return router;
+}

--- a/apps/backend-js/src/routes/validate.js
+++ b/apps/backend-js/src/routes/validate.js
@@ -1,0 +1,43 @@
+import express from 'express';
+import multer from 'multer';
+
+const router = express.Router();
+const upload = multer({ limits: { fileSize: 10 * 1024 * 1024 } });
+
+export function createValidateRouter(validatorService) {
+  router.post('/chain', async (req, res) => {
+    try {
+      const { token } = req.body;
+      if (!token) {
+        return res.status(400).json({ error: 'Token is required' });
+      }
+
+      const tokenBytes = Buffer.from(token, 'base64');
+      const result = await validatorService.validateChain(tokenBytes);
+      res.json(result);
+    } catch (error) {
+      res.status(500).json({ 
+        error: 'Validation failed',
+        message: error.message 
+      });
+    }
+  });
+
+  router.post('/chain/file', upload.single('file'), async (req, res) => {
+    try {
+      if (!req.file) {
+        return res.status(400).json({ error: 'File is required' });
+      }
+
+      const result = await validatorService.validateChain(req.file.buffer);
+      res.json(result);
+    } catch (error) {
+      res.status(500).json({ 
+        error: 'Validation failed',
+        message: error.message 
+      });
+    }
+  });
+
+  return router;
+}

--- a/apps/backend-js/src/server.js
+++ b/apps/backend-js/src/server.js
@@ -1,0 +1,103 @@
+import express from 'express';
+import cors from 'cors';
+import swaggerUi from 'swagger-ui-express';
+import { ParserService } from './services/parser.js';
+import { ValidatorService } from './services/validator.js';
+import { GraphService } from './services/graph.js';
+import { createParseRouter } from './routes/parse.js';
+import { createValidateRouter } from './routes/validate.js';
+import { createGraphRouter } from './routes/graph.js';
+import { createUcanValidator } from './middleware/ucanvalidator.js';
+import { swaggerSpec } from './swagger/config.js';
+import { generateExampleTokens } from './swagger/examples.js';
+
+const app = express();
+const PORT = process.env.PORT || 8081;
+
+// Middleware
+app.use(cors());
+app.use(express.json());
+
+// Generate example tokens on startup
+let exampleTokens = {};
+generateExampleTokens()
+  .then(tokens => {
+    exampleTokens = tokens;
+    console.log('✅ Generated example UCAN tokens');
+    console.log('   Parse token:', tokens.parse.substring(0, 50) + '...');
+    console.log('   Validate token:', tokens.validate.substring(0, 50) + '...');
+    console.log('   Graph token:', tokens.graph.substring(0, 50) + '...');
+    console.log('   Admin token:', tokens.admin.substring(0, 50) + '...');
+  })
+  .catch(err => console.warn('⚠️  Failed to generate example tokens:', err.message));
+
+// Initialize services
+const parserService = new ParserService();
+const validatorService = new ValidatorService(parserService);
+const graphService = new GraphService(parserService);
+
+// UCAN validation middleware (DISABLED by default for easy testing)
+app.use(createUcanValidator());
+
+// Swagger UI with UCAN security
+app.use('/swagger', swaggerUi.serve, swaggerUi.setup(swaggerSpec, {
+  customCss: '.swagger-ui .topbar { display: none }',
+  customSiteTitle: 'UCAN Visualization API',
+  swaggerOptions: {
+    persistAuthorization: true
+  }
+}));
+
+// Endpoint to get example tokens
+app.get('/api/examples/tokens', (req, res) => {
+  res.json({
+    message: 'Example UCAN tokens for testing',
+    tokens: exampleTokens,
+    usage: {
+      parse: `Authorization: Bearer ${exampleTokens.parse}`,
+      validate: `Authorization: Bearer ${exampleTokens.validate}`,
+      graph: `Authorization: Bearer ${exampleTokens.graph}`,
+      admin: `Authorization: Bearer ${exampleTokens.admin}`
+    },
+    howToUse: [
+      '1. Copy one of the tokens above',
+      '2. Go to /swagger',
+      '3. Click "Authorize" button',
+      '4. Paste: Bearer <token>',
+      '5. Try the endpoints'
+    ]
+  });
+});
+
+// Swagger JSON
+app.get('/swagger.json', (req, res) => {
+  res.json(swaggerSpec);
+});
+
+// Routes
+app.use('/api/parse', createParseRouter(parserService));
+app.use('/api/validate', createValidateRouter(validatorService));
+app.use('/api/graph', createGraphRouter(graphService));
+
+// Health check
+app.get('/health', (req, res) => {
+  res.json({
+    status: 'healthy',
+    service: 'ucan-backend-js',
+    timestamp: new Date().toISOString(),
+    version: '1.0.0'
+  });
+});
+
+// Root redirect
+app.get('/', (req, res) => {
+  res.redirect('/swagger');
+});
+
+app.listen(PORT, () => {
+  console.log(`UCAN Backend JS running on http://localhost:${PORT}`);
+  console.log(`Health check: http://localhost:${PORT}/health`);
+  console.log(`API Docs: http://localhost:${PORT}/swagger`);
+  console.log(`Example Tokens: http://localhost:${PORT}/api/examples/tokens`);
+  console.log(``);
+});

--- a/apps/backend-js/src/services/graph.js
+++ b/apps/backend-js/src/services/graph.js
@@ -1,0 +1,102 @@
+export class GraphService {
+  constructor(parserService) {
+    this.parser = parserService;
+  }
+
+  async generateDelegationGraph(tokenBytes) {
+    const chain = await this.parser.parseDelegationChain(tokenBytes);
+    const { nodes, edges } = this.#buildGraph(chain);
+    const chainInfo = this.#buildChainInfo(chain);
+
+    return { nodes, edges, chain: chainInfo };
+  }
+
+  async generateInvocationGraph(tokenBytes) {
+    const invocation = await this.parser.parseInvocation(tokenBytes);
+    const chain = await this.parser.parseDelegationChain(tokenBytes);
+    const { nodes, edges } = this.#buildGraph(chain);
+    const chainInfo = this.#buildChainInfo(chain);
+
+    return {
+      nodes,
+      edges,
+      chain: chainInfo,
+      invocation,
+      isInvocation: invocation.isInvocation
+    };
+  }
+
+  #buildGraph(chain) {
+    const nodesMap = new Map();
+    const edges = [];
+    const maxLevel = Math.max(...chain.map(d => d.level));
+
+    for (const del of chain) {
+      if (!nodesMap.has(del.issuer)) {
+        nodesMap.set(del.issuer, {
+          id: del.issuer,
+          label: this.#shortenDID(del.issuer),
+          type: del.level === 0 ? 'root' : 'intermediate',
+          level: del.level,
+          metadata: { fullDID: del.issuer, role: 'delegator' }
+        });
+      }
+
+      if (!nodesMap.has(del.audience)) {
+        nodesMap.set(del.audience, {
+          id: del.audience,
+          label: this.#shortenDID(del.audience),
+          type: del.level === maxLevel ? 'leaf' : 'intermediate',
+          level: del.level,
+          metadata: { fullDID: del.audience, role: 'delegatee' }
+        });
+      }
+
+      for (const cap of del.capabilities) {
+        edges.push({
+          source: del.issuer,
+          target: del.audience,
+          capability: cap,
+          label: `${cap.can} on ${cap.with}`,
+          valid: true,
+          level: del.level,
+          type: 'delegation',
+          metadata: { cid: del.cid }
+        });
+      }
+    }
+
+    return {
+      nodes: Array.from(nodesMap.values()),
+      edges
+    };
+  }
+
+  #buildChainInfo(chain) {
+    if (chain.length === 0) return {};
+
+    const maxLevel = Math.max(...chain.map(d => d.level));
+    const leafCIDs = chain.filter(d => d.level === maxLevel).map(d => d.cid);
+
+    return {
+      totalLevels: maxLevel + 1,
+      isComplete: true,
+      rootCID: chain[0].cid,
+      leafCIDs,
+      principals: [],
+      timeline: []
+    };
+  }
+
+  #shortenDID(did) {
+    if (did.length <= 20) return did;
+    const parts = did.split(':');
+    if (parts.length < 3) return did.slice(0, 20) + '...';
+    
+    const identifier = parts[2];
+    if (identifier.length > 16) {
+      return `did:${parts[1]}:${identifier.slice(0, 8)}...${identifier.slice(-8)}`;
+    }
+    return did;
+  }
+}

--- a/apps/backend-js/src/services/parser.js
+++ b/apps/backend-js/src/services/parser.js
@@ -1,0 +1,250 @@
+import * as Delegation from '@ucanto/core/delegation';
+import * as Block from 'multiformats/block';
+import * as dagCBOR from '@ipld/dag-cbor';
+import { sha256 } from 'multiformats/hashes/sha2';
+
+export class ParserService {
+  async parseDelegation(tokenBytes) {
+    try {
+      const result = await Delegation.extract(tokenBytes);
+      const delegation = result.ok || result;
+      return this.delegationToResponse(delegation, 0);
+    } catch (error) {
+      throw new Error(`Failed to parse delegation: ${error.message}`);
+    }
+  }
+
+  async parseDelegationChain(tokenBytes) {
+    try {
+      const result = await Delegation.extract(tokenBytes);
+      const delegation = result.ok || result;
+      const chain = [];
+      
+      const root = this.delegationToResponse(delegation, 0);
+      chain.push(root);
+
+      if (delegation.proofs && delegation.proofs.length > 0) {
+        const proofDelegations = await this.parseProofs(
+          delegation.proofs, 
+          delegation.blocks,
+          1
+        );
+        chain.push(...proofDelegations);
+      }
+
+      return chain;
+    } catch (error) {
+      throw new Error(`Failed to parse delegation chain: ${error.message}`);
+    }
+  }
+
+  async parseInvocation(tokenBytes) {
+    const delegation = await this.parseDelegation(tokenBytes);
+    const invocationAnalysis = this.analyzeInvocation(delegation);
+    const capabilityAnalysis = this.analyzeCapabilities(delegation.capabilities);
+
+    let task = null;
+    if (invocationAnalysis.isInvocation) {
+      task = {
+        action: invocationAnalysis.primaryAction,
+        resource: invocationAnalysis.targetResource,
+        constraints: invocationAnalysis.constraints,
+        issuer: delegation.issuer,
+        target: delegation.audience,
+        taskType: invocationAnalysis.taskType,
+        permissions: invocationAnalysis.requiredPermissions
+      };
+    }
+
+    return {
+      delegation,
+      isInvocation: invocationAnalysis.isInvocation,
+      task,
+      invocationAnalysis,
+      capabilityAnalysis
+    };
+  }
+
+  delegationToResponse(delegation, level) {
+    const caps = delegation.data?.capabilities || delegation.capabilities || [];
+    
+    const capabilities = caps.map(cap => ({
+      with: cap.with,
+      can: cap.can,
+      nb: cap.nb || {},
+      category: this.categorizeCapability(cap.can)
+    }));
+
+    const proofs = (delegation.proofs || []).map((proof, index) => ({
+      cid: proof.toString ? proof.toString() : String(proof),
+      index,
+      type: 'delegation'
+    }));
+
+    const exp = delegation.data?.expiration || delegation.expiration;
+    const nbf = delegation.data?.notBefore || delegation.notBefore;
+    
+    const expiration = exp ? new Date(exp * 1000).toISOString() : null;
+    const notBefore = nbf ? new Date(nbf * 1000).toISOString() : null;
+
+    const issuer = delegation.issuer?.did ? delegation.issuer.did() : String(delegation.issuer || 'unknown');
+    const audience = delegation.audience?.did ? delegation.audience.did() : String(delegation.audience || 'unknown');
+    const cid = delegation.cid?.toString ? delegation.cid.toString() : String(delegation.cid || 'unknown');
+
+    return {
+      issuer,
+      audience,
+      capabilities,
+      proofs,
+      expiration,
+      notBefore,
+      facts: delegation.data?.facts || delegation.facts || [],
+      nonce: delegation.data?.nonce || delegation.nonce || null,
+      signature: { algorithm: 'EdDSA' },
+      cid,
+      level
+    };
+  }
+
+  async parseProofs(proofLinks, blocks, level) {
+    const proofs = [];
+
+    for (const link of proofLinks) {
+      try {
+        const blockBytes = blocks.get(link);
+        if (!blockBytes) continue;
+
+        const block = await Block.decode({
+          bytes: blockBytes,
+          codec: dagCBOR,
+          hasher: sha256
+        });
+
+        const proofDelegation = await this.blockToDelegation(block, blocks);
+        const parsed = this.delegationToResponse(proofDelegation, level);
+        proofs.push(parsed);
+
+        if (proofDelegation.proofs && proofDelegation.proofs.length > 0) {
+          const nested = await this.parseProofs(
+            proofDelegation.proofs,
+            blocks,
+            level + 1
+          );
+          proofs.push(...nested);
+        }
+      } catch (error) {
+        console.warn(`Failed to parse proof ${link}:`, error.message);
+      }
+    }
+
+    return proofs;
+  }
+
+  async blockToDelegation(block, blocks) {
+    const value = block.value;
+    return {
+      cid: block.cid,
+      issuer: { did: () => value.iss },
+      audience: { did: () => value.aud },
+      data: {
+        capabilities: value.att || [],
+        expiration: value.exp,
+        notBefore: value.nbf,
+        facts: value.fct || [],
+        nonce: value.nnc,
+      },
+      proofs: value.prf || [],
+      blocks
+    };
+  }
+
+  analyzeInvocation(delegation) {
+    const analysis = {
+      isInvocation: false,
+      hasInvokeCapability: false,
+      taskType: 'delegation',
+      primaryAction: '',
+      targetResource: '',
+      invokePatterns: [],
+      requiredPermissions: [],
+      constraints: {}
+    };
+
+    if (delegation.issuer !== delegation.audience) {
+      analysis.isInvocation = true;
+    }
+
+    for (const cap of delegation.capabilities) {
+      if (this.isInvokeCapability(cap.can)) {
+        analysis.hasInvokeCapability = true;
+        analysis.taskType = 'invocation';
+        analysis.invokePatterns.push(cap.can);
+        analysis.primaryAction = cap.can;
+        analysis.targetResource = cap.with;
+      }
+
+      if (cap.can) {
+        analysis.requiredPermissions.push(cap.can);
+      }
+
+      if (cap.nb) {
+        Object.assign(analysis.constraints, cap.nb);
+      }
+    }
+
+    if (!analysis.primaryAction && delegation.capabilities.length > 0) {
+      analysis.primaryAction = delegation.capabilities[0].can;
+      analysis.targetResource = delegation.capabilities[0].with;
+    }
+
+    return analysis;
+  }
+
+  analyzeCapabilities(capabilities) {
+    const analysis = {
+      categories: {},
+      totalCount: capabilities.length,
+      invokeCount: 0,
+      delegateCount: 0,
+      permissions: [],
+      resources: []
+    };
+
+    for (const cap of capabilities) {
+      const category = cap.category || 'unknown';
+      
+      if (!analysis.categories[category]) {
+        analysis.categories[category] = [];
+      }
+      analysis.categories[category].push(cap);
+
+      if (this.isInvokeCapability(cap.can)) {
+        analysis.invokeCount++;
+      } else {
+        analysis.delegateCount++;
+      }
+
+      if (cap.can) analysis.permissions.push(cap.can);
+      if (cap.with) analysis.resources.push(cap.with);
+    }
+
+    return analysis;
+  }
+
+  isInvokeCapability(capability) {
+    const invokePatterns = ['invoke', 'execute', 'run', 'call', 'perform'];
+    return invokePatterns.some(pattern => 
+      capability.toLowerCase().includes(pattern)
+    );
+  }
+
+  categorizeCapability(capability) {
+    if (capability.startsWith('store')) return 'storage';
+    if (capability.startsWith('space')) return 'space';
+    if (capability.startsWith('upload')) return 'upload';
+    if (this.isInvokeCapability(capability)) return 'invocation';
+    if (capability.startsWith('blob')) return 'blob';
+    if (capability.startsWith('index')) return 'index';
+    return 'general';
+  }
+}

--- a/apps/backend-js/src/services/validator.js
+++ b/apps/backend-js/src/services/validator.js
@@ -1,0 +1,164 @@
+export class ValidatorService {
+  constructor(parserService) {
+    this.parser = parserService;
+  }
+
+  async validateChain(tokenBytes) {
+    try {
+      const chain = await this.parser.parseDelegationChain(tokenBytes);
+      const chainLinks = [];
+      const allIssues = [];
+
+      for (const delegation of chain) {
+        const link = this.#validateDelegation(delegation);
+        chainLinks.push(link);
+        allIssues.push(...link.issues);
+      }
+
+      const summary = this.#buildSummary(chainLinks);
+      let rootCause = null;
+      
+      if (summary.invalidLinks > 0) {
+        rootCause = this.#findRootCause(allIssues, chainLinks[0]);
+      }
+
+      return {
+        valid: summary.invalidLinks === 0,
+        chain: chainLinks,
+        rootCause,
+        summary
+      };
+    } catch (error) {
+      return {
+        valid: false,
+        rootCause: {
+          type: 'parse_error',
+          message: `Failed to parse UCAN: ${error.message}`
+        },
+        summary: {
+          totalLinks: 0,
+          validLinks: 0,
+          invalidLinks: 0,
+          warningCount: 0
+        }
+      };
+    }
+  }
+
+  #validateDelegation(delegation) {
+    const issues = [];
+    const now = new Date();
+
+    if (delegation.expiration) {
+      const expiration = new Date(delegation.expiration);
+      
+      if (expiration < now) {
+        const timeExpired = Math.floor((now - expiration) / 60000);
+        issues.push({
+          type: 'expired',
+          message: `UCAN expired ${this.#formatDuration(timeExpired)} ago`,
+          severity: 'error'
+        });
+      } else if (expiration < new Date(now.getTime() + 24 * 60 * 60 * 1000)) {
+        const timeUntil = Math.floor((expiration - now) / 60000);
+        issues.push({
+          type: 'expiring_soon',
+          message: `UCAN expires in ${this.#formatDuration(timeUntil)}`,
+          severity: 'warning'
+        });
+      }
+    }
+
+    if (delegation.notBefore) {
+      const notBefore = new Date(delegation.notBefore);
+      if (notBefore > now) {
+        issues.push({
+          type: 'not_yet_valid',
+          message: `UCAN not valid until ${notBefore.toISOString()}`,
+          severity: 'error'
+        });
+      }
+    }
+
+    if (delegation.capabilities.length === 0) {
+      issues.push({
+        type: 'no_capabilities',
+        message: 'Delegation has no capabilities',
+        severity: 'warning'
+      });
+    }
+
+    const capability = delegation.capabilities[0] || {
+      with: '', can: '', nb: {}
+    };
+
+    const valid = this.#countErrors(issues) === 0;
+
+    return {
+      level: delegation.level,
+      cid: delegation.cid,
+      issuer: delegation.issuer,
+      audience: delegation.audience,
+      capability,
+      expiration: delegation.expiration,
+      notBefore: delegation.notBefore,
+      valid,
+      issues
+    };
+  }
+
+  #buildSummary(links) {
+    const summary = {
+      totalLinks: links.length,
+      validLinks: 0,
+      invalidLinks: 0,
+      warningCount: 0
+    };
+
+    for (const link of links) {
+      if (link.valid) {
+        summary.validLinks++;
+      } else {
+        summary.invalidLinks++;
+      }
+
+      for (const issue of link.issues) {
+        if (issue.severity === 'warning') {
+          summary.warningCount++;
+        }
+      }
+    }
+
+    return summary;
+  }
+
+  #findRootCause(issues, firstLink) {
+    for (const issue of issues) {
+      if (issue.severity === 'error') {
+        return {
+          type: issue.type,
+          message: issue.message,
+          link: {
+            issuer: firstLink.issuer,
+            audience: firstLink.audience
+          }
+        };
+      }
+    }
+    return null;
+  }
+
+  #countErrors(issues) {
+    return issues.filter(i => i.severity === 'error').length;
+  }
+
+  #formatDuration(minutes) {
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    if (hours < 24) return `${hours}h ${mins}m`;
+    const days = Math.floor(hours / 24);
+    const hrs = hours % 24;
+    return `${days}d ${hrs}h`;
+  }
+}

--- a/apps/backend-js/src/swagger/capabilities.js
+++ b/apps/backend-js/src/swagger/capabilities.js
@@ -1,0 +1,63 @@
+/**
+ * Capability Registry - Maps endpoints to required UCAN capabilities
+ */
+export const capabilityRegistry = {
+    // Parse endpoints - require 'parse' capability
+    'POST /api/parse/delegation': {
+      capabilities: [{ can: 'ucan/parse', with: 'api:*' }],
+      description: 'Parse UCAN delegation tokens'
+    },
+    'POST /api/parse/chain': {
+      capabilities: [{ can: 'ucan/parse', with: 'api:*' }],
+      description: 'Parse UCAN delegation chains'
+    },
+    'POST /api/parse/invocation': {
+      capabilities: [{ can: 'ucan/parse', with: 'api:*' }],
+      description: 'Parse UCAN invocations'
+    },
+    
+    // Validate endpoints - require 'validate' capability
+    'POST /api/validate/chain': {
+      capabilities: [{ can: 'ucan/validate', with: 'api:*' }],
+      description: 'Validate UCAN delegation chains'
+    },
+    
+    // Graph endpoints - require 'graph' capability
+    'POST /api/graph/delegation': {
+      capabilities: [{ can: 'ucan/graph', with: 'api:*' }],
+      description: 'Generate delegation graph'
+    },
+    'POST /api/graph/invocation': {
+      capabilities: [{ can: 'ucan/graph', with: 'api:*' }],
+      description: 'Generate invocation graph'
+    }
+  };
+  
+  /**
+   * Check if a delegation has the required capability
+   */
+  export function hasRequiredCapability(delegation, requiredCap) {
+    if (!delegation.capabilities) return false;
+    
+    return delegation.capabilities.some(cap => {
+      const canMatch = cap.can === requiredCap.can || requiredCap.can === '*';
+      const withMatch = matchesResource(cap.with, requiredCap.with);
+      return canMatch && withMatch;
+    });
+  }
+  
+  /**
+   * Match resources with wildcard support
+   */
+  function matchesResource(actual, required) {
+    if (required === '*') return true;
+    if (actual === required) return true;
+    
+    // Handle wildcards like "api:*" matching "api:parse"
+    if (required.endsWith(':*')) {
+      const prefix = required.slice(0, -1);
+      return actual.startsWith(prefix);
+    }
+    
+    return false;
+  }

--- a/apps/backend-js/src/swagger/config.js
+++ b/apps/backend-js/src/swagger/config.js
@@ -1,0 +1,267 @@
+/**
+ * Simple Swagger configuration with UCAN security
+ */
+export const swaggerSpec = {
+    openapi: '3.0.0',
+    info: {
+      title: 'UCAN Visualization API',
+      version: '1.0.0',
+      description: `
+  # UCAN-Secured API
+  
+  This API validates UCAN tokens for authorization.
+  
+  ## How to Use
+  
+  1. Get a UCAN token from /api/examples/tokens
+  2. Click "Authorize" button below
+  3. Enter: \`Bearer <your-token>\`
+  4. Try the endpoints
+  
+  ## Example Tokens
+  
+  Visit http://localhost:8081/api/examples/tokens to get fresh tokens.
+  
+  Each endpoint requires specific capabilities:
+  - **Parse endpoints**: \`ucan/parse\` on \`api:*\`
+  - **Validate endpoints**: \`ucan/validate\` on \`api:*\`
+  - **Graph endpoints**: \`ucan/graph\` on \`api:*\`
+  - **Admin token**: All capabilities
+      `
+    },
+    servers: [
+      { url: 'http://localhost:8081', description: 'Development' }
+    ],
+    components: {
+      securitySchemes: {
+        UCANBearer: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'UCAN',
+          description: 'UCAN token with required capabilities. Get tokens from /api/examples/tokens'
+        }
+      },
+      schemas: {
+        TokenInput: {
+          type: 'object',
+          required: ['token'],
+          properties: {
+            token: {
+              type: 'string',
+              format: 'byte',
+              description: 'Base64-encoded UCAN token in CAR format'
+            }
+          }
+        },
+        Error: {
+          type: 'object',
+          properties: {
+            error: { type: 'string' },
+            message: { type: 'string' }
+          }
+        }
+      }
+    },
+    security: [{ UCANBearer: [] }],
+    paths: {
+      '/health': {
+        get: {
+          tags: ['System'],
+          summary: 'Health check',
+          description: 'Check if the service is running',
+          security: [],
+          responses: {
+            '200': { 
+              description: 'Service is healthy',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      status: { type: 'string' },
+                      service: { type: 'string' },
+                      timestamp: { type: 'string' },
+                      version: { type: 'string' }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      '/api/examples/tokens': {
+        get: {
+          tags: ['System'],
+          summary: 'Get example UCAN tokens',
+          description: 'Returns example tokens for testing each endpoint',
+          security: [],
+          responses: {
+            '200': {
+              description: 'Example tokens',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      message: { type: 'string' },
+                      tokens: { type: 'object' },
+                      usage: { type: 'object' }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      '/api/parse/delegation': {
+        post: {
+          tags: ['Parse'],
+          summary: 'Parse UCAN delegation',
+          description: '**Required capability:** `ucan/parse` on `api:*`\n\nExtracts delegation information from a UCAN token.',
+          security: [{ UCANBearer: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/TokenInput' }
+              }
+            }
+          },
+          responses: {
+            '200': { description: 'Successfully parsed delegation' },
+            '401': { 
+              description: 'Missing UCAN token',
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/Error' }
+                }
+              }
+            },
+            '403': { 
+              description: 'Insufficient capabilities',
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/Error' }
+                }
+              }
+            },
+            '422': {
+              description: 'Failed to parse delegation',
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/Error' }
+                }
+              }
+            }
+          }
+        }
+      },
+      '/api/parse/chain': {
+        post: {
+          tags: ['Parse'],
+          summary: 'Parse delegation chain',
+          description: '**Required capability:** `ucan/parse` on `api:*`\n\nParses a full UCAN delegation chain including all proofs.',
+          security: [{ UCANBearer: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/TokenInput' }
+              }
+            }
+          },
+          responses: {
+            '200': { description: 'Successfully parsed chain' },
+            '403': { description: 'Insufficient capabilities' },
+            '422': { description: 'Failed to parse chain' }
+          }
+        }
+      },
+      '/api/parse/invocation': {
+        post: {
+          tags: ['Parse'],
+          summary: 'Parse UCAN invocation',
+          description: '**Required capability:** `ucan/parse` on `api:*`\n\nAnalyzes a UCAN invocation and extracts task information.',
+          security: [{ UCANBearer: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/TokenInput' }
+              }
+            }
+          },
+          responses: {
+            '200': { description: 'Successfully analyzed invocation' },
+            '403': { description: 'Insufficient capabilities' },
+            '422': { description: 'Failed to parse invocation' }
+          }
+        }
+      },
+      '/api/validate/chain': {
+        post: {
+          tags: ['Validate'],
+          summary: 'Validate delegation chain',
+          description: '**Required capability:** `ucan/validate` on `api:*`\n\nValidates a UCAN delegation chain and identifies any issues.',
+          security: [{ UCANBearer: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/TokenInput' }
+              }
+            }
+          },
+          responses: {
+            '200': { description: 'Validation result' },
+            '403': { description: 'Insufficient capabilities' },
+            '500': { description: 'Validation failed' }
+          }
+        }
+      },
+      '/api/graph/delegation': {
+        post: {
+          tags: ['Graph'],
+          summary: 'Generate delegation graph',
+          description: '**Required capability:** `ucan/graph` on `api:*`\n\nGenerates a node-edge graph for visualizing the delegation.',
+          security: [{ UCANBearer: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/TokenInput' }
+              }
+            }
+          },
+          responses: {
+            '200': { description: 'Graph data' },
+            '403': { description: 'Insufficient capabilities' },
+            '422': { description: 'Failed to generate graph' }
+          }
+        }
+      },
+      '/api/graph/invocation': {
+        post: {
+          tags: ['Graph'],
+          summary: 'Generate invocation graph',
+          description: '**Required capability:** `ucan/graph` on `api:*`\n\nGenerates an enhanced graph with invocation markers.',
+          security: [{ UCANBearer: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/TokenInput' }
+              }
+            }
+          },
+          responses: {
+            '200': { description: 'Invocation graph data' },
+            '403': { description: 'Insufficient capabilities' },
+            '422': { description: 'Failed to generate graph' }
+          }
+        }
+      }
+    }
+  };

--- a/apps/backend-js/src/swagger/examples.js
+++ b/apps/backend-js/src/swagger/examples.js
@@ -1,0 +1,58 @@
+import * as ed25519 from '@ucanto/principal/ed25519';
+import * as Client from '@ucanto/client';
+
+/**
+ * Generate example UCAN tokens for documentation
+ */
+export async function generateExampleTokens() {
+  const issuer = await ed25519.generate();
+  const audience = await ed25519.generate();
+
+  const tokens = {};
+
+  // Parse token
+  const parseDelegation = await Client.delegate({
+    issuer,
+    audience,
+    capabilities: [{ can: 'ucan/parse', with: 'api:*' }],
+    expiration: Math.floor(Date.now() / 1000) + 86400
+  });
+  const parseArchive = await parseDelegation.archive();
+  tokens.parse = Buffer.from(parseArchive.ok).toString('base64');
+
+  // Validate token
+  const validateDelegation = await Client.delegate({
+    issuer,
+    audience,
+    capabilities: [{ can: 'ucan/validate', with: 'api:*' }],
+    expiration: Math.floor(Date.now() / 1000) + 86400
+  });
+  const validateArchive = await validateDelegation.archive();
+  tokens.validate = Buffer.from(validateArchive.ok).toString('base64');
+
+  // Graph token
+  const graphDelegation = await Client.delegate({
+    issuer,
+    audience,
+    capabilities: [{ can: 'ucan/graph', with: 'api:*' }],
+    expiration: Math.floor(Date.now() / 1000) + 86400
+  });
+  const graphArchive = await graphDelegation.archive();
+  tokens.graph = Buffer.from(graphArchive.ok).toString('base64');
+
+  // Admin token (all capabilities)
+  const adminDelegation = await Client.delegate({
+    issuer,
+    audience,
+    capabilities: [
+      { can: 'ucan/parse', with: 'api:*' },
+      { can: 'ucan/validate', with: 'api:*' },
+      { can: 'ucan/graph', with: 'api:*' }
+    ],
+    expiration: Math.floor(Date.now() / 1000) + 86400
+  });
+  const adminArchive = await adminDelegation.archive();
+  tokens.admin = Buffer.from(adminArchive.ok).toString('base64');
+
+  return tokens;
+}


### PR DESCRIPTION
 UCAN Swagger Documentation Pattern
A reusable pattern for documenting UCAN-based APIs with OpenAPI/Swagger

Added interactive API documentation to any UCAN-secured service with capability-based authorization, example token generation, and automatic validation.

A **complete reference implementation** showing how to integrate UCAN (User Controlled Authorization Networks) with OpenAPI/Swagger documentation.

This implementation provides:
- **Capability Registry** - Map endpoints to required UCAN capabilities
- **UCAN Validator Middleware** - Validate Bearer tokens with capability checking
- **Example Token Generator** - Auto-generate valid UCANs for testing
- **Interactive Swagger UI** - Try endpoints with  UCAN tokens

